### PR TITLE
Set requirment jnius -> pyjnius

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
     description='A simple python module to bring together the worlds of numpy (Python) and ImgLib2 (Java).',
     packages=['imglyb'],
     py_modules=['imglyb_config'],
-    install_requires=['numpy', 'jnius', 'jrun']
+    install_requires=['numpy', 'pyjnius', 'jrun']
 )


### PR DESCRIPTION
The setup.py file lists jnius as a requirement.  Jnius has been renamed to pyjnius, and so this can send conda installation warnings when installing imglyb, which can be confusing for new users.

This change just renames the requirement to pyjnius to reduce confusion.