### PR TITLE
Do not flip dimension order

### DIFF
--- a/imglyb/__init__.py
+++ b/imglyb/__init__.py
@@ -32,10 +32,10 @@ def _init_jvm_options():
 
     import scyjava
 
-    return jnius_config, scyjava
+    return jnius_config
 
 
-config, _ = _init_jvm_options()
+config = _init_jvm_options()
 
 from .imglib_ndarray import ImgLibReferenceGuard as _ImgLibReferenceGuard
 from .util import \

--- a/imglyb/util.py
+++ b/imglyb/util.py
@@ -85,11 +85,11 @@ def _to_imglib(source):
     address = _get_address(source)
     if not source.dtype in numpy_dtype_to_conversion_method:
         raise NotImplementedError("Cannot convert dtype to ImgLib2 type yet: {}".format(source.dtype))
-    elif source.flags['CARRAY']:
-        return numpy_dtype_to_conversion_method[source.dtype](address, *source.shape[::-1])
+    elif np.isfortran(source):
+        return numpy_dtype_to_conversion_method[source.dtype](address, *source.shape)
     else:
-        stride = np.array(source.strides[::-1]) / source.itemsize
-        return numpy_dtype_to_conversion_with_stride_method[source.dtype](address, tuple(stride), source.shape[::-1])
+        stride = np.array(source.strides) / source.itemsize
+        return numpy_dtype_to_conversion_with_stride_method[source.dtype](address, tuple(stride), source.shape)
 
 
 def to_imglib_argb(source):
@@ -100,11 +100,11 @@ def _to_imglib_argb(source):
     address = _get_address(source)
     if not (source.dtype == np.dtype('int32') or source.dtype == np.dtype('uint32')):
         raise NotImplementedError("source.dtype must be int32 or uint32")
-    if source.flags['CARRAY']:
-        return NumpyToImgLibConversions.toARGB(address, *source.shape[::-1])
+    elif np.isfortran(source):
+        return NumpyToImgLibConversions.toARGB(address, *source.shape)
     else:
-        stride = np.array(source.strides[::-1]) / source.itemsize
-        return NumpyToImgLibConversionsWithStride.toARGB(address, tuple(stride), source.shape[::-1])
+        stride = np.array(source.strides) / source.itemsize
+        return NumpyToImgLibConversionsWithStride.toARGB(address, tuple(stride), source.shape)
 
 
 def options2D():


### PR DESCRIPTION
When wrapping a numpy array to an ImgLib2 image, the dimension order is reversed. For example, a 3D numpy array dimensioned [3, 5, 7] would become a 3D `RandomAccessibleInterval` dimensioned [7, 5, 3]. This PR attempts to fix that inconsistency such that dimensions stay consistent across the two worlds.

A numpy array has [two different orders](https://www.geeksforgeeks.org/numpy-isfortran-python/):
> C is column-contiguous order in memory (last index varies the fastest). C order means that operating row-rise on the array will be slightly quicker. FORTRAN-contiguous order in memory (first index varies the fastest). F order means that column-wise operations will be faster.

ImgLib2 generally prefers F order. In particular, the `Views.flatIterable` method returns an `IterableInterval` in F order, and the `IntervalIndexer` methods perform F-ordered rasterization.

On the Python side: if you do not specify an order, then numpy arrays default to C order.

@hanslovsky Is this discrepancy between ImgLib2's general preference and NumPy's default preference the reason for inverting the axes? Or is there another reason?

Since NumPy supports both C and F, my strong vote is to discontinue this dimension flipping behavior, in favor of consistently keeping everything the same.

@hanslovsky If you agree, I can polish up this PR. Certainly, I would add unit tests to prove that all works as expected in the various cases.

Alternately, if breaking existing behavior makes you nervous, we could add a `flip_dimensions` flag to the `to_imglib` method, defaulting to `True`. I would still change pyimagej to pass `False` for this flag though, because I think it's good to reduce the number of things our less technical users need to know about and work around.