### PR TITLE
Fix up ImgLibReferenceGuard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .classpath
 .project
 .settings
+.vscode
 target
 __pycache__
 build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "test"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/imglyb/imglib_ndarray.py
+++ b/imglyb/imglib_ndarray.py
@@ -11,47 +11,69 @@ def _java_setup():
     Lazy initialization function for Java-dependent data structures.
     Do not call this directly; use scyjava.start_jvm() instead.
     """
+    global Intervals
     Intervals = scyjava.jimport('net.imglib2.util.Intervals')
 
 scyjava.when_jvm_starts(_java_setup)
 
 dtype_selector = {
     'FloatType': np.dtype('float32'),
+    'FloatLongAccessType': np.dtype('float32'),
     'DoubleType': np.dtype('float64'),
+    'DoubleLongAccessType': np.dtype('float64'),
     'ByteType': np.dtype('int8'),
+    'ByteLongAccessType': np.dtype('int8'),
     'UnsignedByteType': np.dtype('uint8'),
+    'UnsignedByteLongAccessType': np.dtype('uint8'),
     'ShortType': np.dtype('int16'),
+    'ShortLongAccessType': np.dtype('int16'),
     'UnsignedShortType': np.dtype('uint16'),
+    'UnisgnedShortLongAccessType': np.dtype('uint16'),
     'IntType': np.dtype('int32'),
+    'IntLongAccessType': np.dtype('int32'),
     'UnsignedIntType': np.dtype('uint32'),
+    'UnsignedIntLongAccessType': np.dtype('uint32'),
     'LongType': np.dtype('int64'),
+    'LongLongAccessType': np.dtype('int64'),
     'UnsignedLongType': np.dtype('uint64'),
+    'UnsignedLongLongAccessType': np.dtype('uint64'),
 }
 
 ctype_conversions_imglib = {
     'FloatType': ctypes.c_float,
+    'FloatLongAccessType': ctypes.c_float,
     'DoubleType': ctypes.c_double,
+    'DoubleLongAccessType': ctypes.c_double,
     'ByteType': ctypes.c_int8,
+    'ByteLongAccessType': ctypes.c_int8,
     'UnsignedByteType': ctypes.c_uint8,
+    'UnsignedByteLongAccessType': ctypes.c_uint8,
     'ShortType': ctypes.c_int16,
+    'ShortLongAccessType': ctypes.c_int16,
     'UnsignedShortType': ctypes.c_uint16,
+    'UnsignedShortLongAccessType': ctypes.c_uint16,
     'IntType': ctypes.c_int32,
+    'IntLongAccessType': ctypes.c_int32,
     'UnsignedIntType': ctypes.c_uint32,
+    'UnsignedIntLongAccessType': ctypes.c_uint32,
     'LongType': ctypes.c_int64,
-    'UnsignedLongType': ctypes.c_uint64
+    'LongLongAccessType': ctypes.c_int64,
+    'UnsignedLongType': ctypes.c_uint64,
+    'UnsignedLongLongAccessType': ctypes.c_uint64
 }
 
 
 def get_address(rai):
     scyjava.start_jvm()
-    class_name = util.Helpers.classNameSimple(rai)
-    class_name_full = util.Helpers.className(rai)
+    class_name = scyjava.to_python(util.Helpers.classNameSimple(rai))
+    class_name_full = scyjava.to_python(util.Helpers.className(rai))
     if class_name in ('ArrayImg', 'UnsafeImg'):
-        access = jpype.JObject(class_name_full, rai).update(None)
-        access_type = util.Helpers.className(access)
+        img_class = scyjava.jimport(class_name_full)
+        access = jpype.JObject(rai, img_class).update(None)
+        access_type = scyjava.to_python(util.Helpers.className(access))
 
         if 'basictypelongaccess.unsafe' in access_type:
-            return jpype.JObject(access_type, access).getAddress()
+            return jpype.JObject(access, access_type).getAddress()
         else:
             raise ValueError("Excpected unsafe access but got {}".format(access_type))
 
@@ -61,18 +83,24 @@ def get_address(rai):
 
 class ImgLibReferenceGuard(np.ndarray):
     def __new__(cls, rai):
+        # Access the address of the rai's data
         access = rai.randomAccess()
         rai.min(access)
         imglib_type = util.Helpers.classNameSimple(access.get())
         address = get_address(rai)
 
+        # Set python properties
         shape = tuple(Intervals.dimensionsAsLongArray(rai))[::-1]
         dtype = dtype_selector[imglib_type]
+
+        # Create a ctypes pointer to the data
         pointer = ctypes.cast(address, ctypes.POINTER(ctype_conversions_imglib[imglib_type]))
         order = 'C'
 
+        # Create a new numpy array 
         obj = np.ndarray.__new__(cls, buffer=np.ctypeslib.as_array(pointer, shape=shape), shape=shape, dtype=dtype)
         obj.setflags(write=True)
+        # Maintain a reference to the java object
         obj.rai = rai
         return obj
 

--- a/test/test_imglyb.py
+++ b/test/test_imglyb.py
@@ -2,6 +2,9 @@ import pytest
 import imglyb
 import numpy as np
 import scyjava
+from scyjava import config
+
+from imglyb.imglib_ndarray import ImgLibReferenceGuard
 
 class TestImglyb(object):
     def test_arraylike(self, sj_fixture):
@@ -17,3 +20,28 @@ class TestImglyb(object):
         while cursor.hasNext():
             assert expected == cursor.next().get()
             expected += 1
+    
+
+    @pytest.fixture
+    def unsafe_img(self):
+        UnsafeImgs = scyjava.jimport('net.imglib2.img.unsafe.UnsafeImgs')
+        return UnsafeImgs.bytes(2, 3, 4)
+
+   
+    def test_to_numpy_returns_ndarray(self, unsafe_img):
+        thing = imglyb.to_numpy(unsafe_img)
+        assert isinstance(thing, np.ndarray)
+
+
+    def test_to_numpy_modification(self, unsafe_img):
+        thing = imglyb.to_numpy(unsafe_img)
+        assert isinstance(thing, np.ndarray)
+
+        fill_value = 2
+
+        thing.fill(fill_value)
+
+        cursor = unsafe_img.cursor()
+        while(cursor.hasNext()):
+            assert cursor.next().get() == fill_value
+        

--- a/test/test_imglyb.py
+++ b/test/test_imglyb.py
@@ -1,10 +1,11 @@
+from jpype import JArray, JInt
 import pytest
 import imglyb
 import numpy as np
 import scyjava
 from scyjava import config
 
-from imglyb.imglib_ndarray import ImgLibReferenceGuard
+from imglyb.imglib_ndarray import ImgLibReferenceGuard, NumpyView
 
 class TestImglyb(object):
     def test_arraylike(self, sj_fixture):
@@ -35,7 +36,6 @@ class TestImglyb(object):
 
     def test_to_numpy_modification(self, unsafe_img):
         thing = imglyb.to_numpy(unsafe_img)
-        assert isinstance(thing, np.ndarray)
 
         fill_value = 2
 
@@ -44,4 +44,97 @@ class TestImglyb(object):
         cursor = unsafe_img.cursor()
         while(cursor.hasNext()):
             assert cursor.next().get() == fill_value
+
+class TestRAIAsNumpyArray:
+    @pytest.fixture
+    def img(self):
+        ArrayImgs = scyjava.jimport('net.imglib2.img.array.ArrayImgs')
+        img = ArrayImgs.unsignedBytes(2, 3, 4)
+        tmp_val = 1
+        cursor = img.cursor()
+        while(cursor.hasNext()):
+            cursor.next().set(tmp_val)
+            tmp_val = tmp_val + 1
+        return img
+    
+    @pytest.fixture
+    def raiAsNumpyArray(self, img):
+        # populate each index with a unique value
+        return NumpyView(img)
+
+    def test_get_tuple(self, img, raiAsNumpyArray):
+        ra = img.randomAccess()
+        arr = JArray(JInt)(3)
+        arr[:] = [1, 1, 1]
+        j_val = ra.setPositionAndGet(arr).get()
+        assert j_val == raiAsNumpyArray[1, 1, 1]
+    
+    def test_get_int(self, img, raiAsNumpyArray):
+        for slice_val in range(len(raiAsNumpyArray)):
+            slice = raiAsNumpyArray[slice_val]
+            for i in range(slice.shape[0]):
+                for j in range(slice.shape[1]):
+                    assert slice[i, j] == raiAsNumpyArray[slice_val, i, j]
+    
+
+    def test_change_rai(self, img, raiAsNumpyArray):
+        """Tests that changes in the img affect the numpy array"""
+        ra = img.randomAccess()
+        arr = JArray(JInt)(3)
+        arr[:] = [1, 1, 1]
+        inserted_val = 100
+        ra.setPositionAndGet(arr).set(inserted_val)
+        assert inserted_val == raiAsNumpyArray[1, 1, 1]
+
+    def test_change_ndarray(self, img, raiAsNumpyArray):
+        """Tests that changes in the numpy array affect the img"""
+        # Change the value
+        inserted_val = 100
+        raiAsNumpyArray[1, 1, 1] = inserted_val
+        ra = img.randomAccess()
+        arr = JArray(JInt)(3)
+        arr[:] = [1, 1, 1]
+        assert inserted_val == ra.setPositionAndGet(arr).get()
+
+    def test_size(self, img, raiAsNumpyArray: np.ndarray):
+        """Tests any behavior."""
+        Intervals = scyjava.jimport('net.imglib2.util.Intervals')
+        assert Intervals.numElements(img) == raiAsNumpyArray.size
+
+    @pytest.fixture
+    def simple_wrapper(self, simple_img):
+        # populate each index with a unique value
+        return NumpyView(simple_img)
+
+    def test_all(self, img, raiAsNumpyArray: np.ndarray):
+        """Tests any behavior."""
+        # simple_img starts out with a one -> Should be true
+        assert raiAsNumpyArray.all() == True
+        assert np.all(raiAsNumpyArray) == True
+
+        # set all values to zero
+        cursor = img.cursor()
+        while cursor.hasNext():
+            cursor.next().set(0)
+            # should be false
+            assert raiAsNumpyArray.all() == False
+            assert np.all(raiAsNumpyArray) == False
+
+
+    def test_any(self, img, raiAsNumpyArray: np.ndarray):
+        """Tests any behavior."""
+        # simple_img starts out with a one -> Should be true
+        assert raiAsNumpyArray.any() == True
+        assert np.any(raiAsNumpyArray) == True
+
+        # set all values to zero
+        cursor = img.cursor()
+        while cursor.hasNext():
+            cursor.next().set(0)
+
+        # now should be false
+        assert raiAsNumpyArray.any() == False
+        assert np.any(raiAsNumpyArray) == False
+
+
         


### PR DESCRIPTION
This PR fixes up @hanslovsky's `ImgLibReferenceGuard` to work on `UnsafeImg`s, and adds a few tests to ensure that the conversion works.