### PR TITLE
Use the `ruff` linter/formatter and add `pre-commit`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,24 +41,17 @@ jobs:
         python -m pytest -s -p no:faulthandler --color=yes
         echo "Done!"
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: psf/black@stable
-
-  flake:
+  ensure-clean-code:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v3
-      - name: flake src code
+
+      - name: Lint code
         run: |
-          python -m pip install flake8 Flake8-pyproject
-          python -m flake8 src
-      - name: flake test code
-        run: |
-          python -m flake8 tests
+          python -m pip install ruff
+          ruff check
+          ruff format --check
 
   conda-dev-test:
     name: Test Conda Development Setup And Code Coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # ruff version
+    rev: v0.9.1
+    hooks:
+      # run the linter
+      - id: ruff
+      # run the formatter
+      - id: ruff-format
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.10.1
+    hooks:
+      - id: validate-pyproject

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ check:
 lint: check
 	bin/lint.sh
 
+fmt: check
+	bin/fmt.sh
+
 test: check
 	bin/test.sh
 

--- a/bin/fmt.sh
+++ b/bin/fmt.sh
@@ -4,10 +4,8 @@ dir=$(dirname "$0")
 cd "$dir/.."
 
 exitCode=0
-ruff check
+ruff check --fix
 code=$?; test $code -eq 0 || exitCode=$code
-ruff format --check
-code=$?; test $code -eq 0 || exitCode=$code
-validate-pyproject pyproject.toml
+ruff format
 code=$?; test $code -eq 0 || exitCode=$code
 exit $exitCode

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - scyjava
   # Developer tools
   - build
+  - pre-commit
   - pytest
   - pytest-cov
   - ruff

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -25,17 +25,13 @@ dependencies:
   - numpy
   - scyjava
   # Developer tools
-  - autopep8
-  - black
   - build
-  - flake8
-  - flake8-pyproject
-  - isort
   - pytest
   - pytest-cov
+  - ruff
   - toml
   # Project from source
   - pip
   - pip:
     - validate-pyproject[all]
-    - -e '.'
+    - -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,10 @@ dependencies = [
 [project.optional-dependencies]
 # NB: Keep this in sync with dev-environment.yml!
 dev = [
-    "autopep8",
-    "black",
     "build",
-    "flake8",
-    "isort",
     "pytest",
     "pytest-cov",
+    "ruff",
     "toml",
     "validate-pyproject[all]",
 ]
@@ -76,13 +73,22 @@ include-package-data = false
 where = ["src"]
 namespaces = false
 
-# Thanks to Flake8-pyproject, we can configure flake8 here!
-[tool.flake8]
-exclude = ["bin", "build", "docs", "dist"]
-extend-ignore = ["E203"]
-# See https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#flake8
-max-line-length = 88
-min_python_version = "3.8"
+# ruff configuration
+[tool.ruff]
+line-length = 88
+src = ["src", "tests"]
+include = ["pyproject.toml", "src/**/*.py", "tests/**/*.py"]
+extend-exclude = ["bin", "build", "dist"]
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+extend-ignore = ["E203"]
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `E402` (import violations) in all `__init__.py` files, and in `path/to/file.py`.
+"__init__.py" = ["E402", "F401"]
+
+[tool.pytest.ini_options]
+addopts = "--ignore=docs"
+testpaths = [
+    "tests",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 dev = [
     "build",
     "pytest",
+    "pre-commit",
     "pytest-cov",
     "ruff",
     "toml",


### PR DESCRIPTION
This PR implements `ruff` as our linter/formatter to replace `autopep8`, `black`, `flake8` and `isort`. It also adds `pre-commit` to the repo.